### PR TITLE
13 dados estatsticos de queimadas

### DIFF
--- a/server/api/controllers/estatisticas/controller.ts
+++ b/server/api/controllers/estatisticas/controller.ts
@@ -8,7 +8,7 @@ import {
 
 async function getEstatisticasMunicipios(req: Request, res: Response) {
   const municipio: string = req.params.municipio.toString();
-  const ano: string = req.params.ano?.toString();
+  const ano: string | undefined = req.query.year?.toString();
 
   const result = await estatisticasMunicipios(municipio, ano);
   return res.status(result ? 200 : 204).send(result);
@@ -16,7 +16,7 @@ async function getEstatisticasMunicipios(req: Request, res: Response) {
 
 async function getEstatisticasEstados(req: Request, res: Response) {
   const estado: string = req.params.estado.toString();
-  const ano: string = req.params.ano?.toString();
+  const ano: string | undefined = req.query.year?.toString();
 
   const result = await estatisticasEstados(estado, ano);
   return res.status(result ? 200 : 204).send(result);

--- a/server/api/controllers/estatisticas/router.ts
+++ b/server/api/controllers/estatisticas/router.ts
@@ -4,7 +4,5 @@ import controller from './controller';
 export default Router()
   .get('/municipios/', controller.findMunicipios)
   .get('/municipios/:municipio', controller.getEstatisticasMunicipios)
-  .get('/municipios/:municipio/:ano', controller.getEstatisticasMunicipios)
   .get('/estados/', controller.findEstados)
-  .get('/estados/:estado', controller.getEstatisticasEstados)
-  .get('/estados/:estado/:ano', controller.getEstatisticasEstados);
+  .get('/estados/:estado', controller.getEstatisticasEstados);

--- a/server/api/services/estatisticas.service.ts
+++ b/server/api/services/estatisticas.service.ts
@@ -1,158 +1,137 @@
 import knex from '../../common/knex';
 
+interface estatistica_mes {
+  mes: number;
+  area_queimada: number;
+  focos: number | string;
+  percentual: number;
+}
+
+interface estatistica_ano {
+  ano: number;
+  area_queimada: number;
+  focos: number | string;
+  percentual: number;
+  meses: Array<estatistica_mes>;
+}
+
 export async function municipiosComDados() {
-  const query = await knex.raw(
-    `select 
+  const query = await knex.raw(`
+    select 
       distinct est.referencia_id as id, 
       dm.nome as nome, 
       dm.uf_sigla as sigla  
     from estatisticas_queimadas_municipios est
     join dados_municipios dm on dm.id = est.referencia_id 
     order by dm.nome 
-  `
-  );
+  `);
   return query.rows;
 }
 
 export async function estadosComDados() {
-  const query = await knex.raw(
-    `select 
+  const query = await knex.raw(`
+    select 
       distinct dm.uf_id as id, 
       dm.uf_nome as nome, 
       dm.uf_sigla as sigla  
     from estatisticas_queimadas_municipios est
     join dados_municipios dm on dm.id = est.referencia_id 
     order by dm.uf_nome  
-  `
-  );
+  `);
   return query.rows;
 }
 
-export async function estatisticasEstados(estado: string, ano?: string) {
-  if (ano) {
-    const query_meses = await knex.raw(
-      `
-    select 
- 	  est.mes,
-      SUM(total_area_queimada) as area_queimada,
-      SUM(total_focos_queimada) as focos,
-      (SUM(total_area_queimada)/
-      (select ST_AREA(me.wkb_geometry, true) from mapas_estados me where me.id = ${estado})) * 100 as percentual
-  from estatisticas_queimadas_municipios est
-  join dados_municipios dm on dm.id = est.referencia_id 
-  where dm.uf_id = ${estado} and est.ano = ${ano} 
-  group by mes
-  order by mes
-`
-    );
-    return query_meses.rows;
-  } else {
-    const anos = await knex.raw(
-      `
-select 
-      est.ano,
-      SUM(total_area_queimada) as area_queimada,
-      SUM(total_focos_queimada) as focos,
-      (SUM(total_area_queimada)/
-      (select ST_AREA(me.wkb_geometry, true) from mapas_estados me where me.id = ${estado})) * 100 as percentual
-  from estatisticas_queimadas_municipios est
-  join dados_municipios dm on dm.id = est.referencia_id 
-  where dm.uf_id = ${estado} 
-  group by ano
-  order by ano
-`
-    );
-
-    const result: any = new Array<any>(anos.rows.length);
-
-    for (let i = 0; i < anos.rows.length; i++) {
-      const ano = anos.rows[i].ano;
-      const query_meses = await knex.raw(
-        `
-    select 
- 	  est.mes,
-      SUM(total_area_queimada) as area_queimada,
-      SUM(total_focos_queimada) as focos,
-      (SUM(total_area_queimada)/
-      (select ST_AREA(me.wkb_geometry, true) from mapas_estados me where me.id = ${estado})) * 100 as percentual
-  from estatisticas_queimadas_municipios est
-  join dados_municipios dm on dm.id = est.referencia_id 
-  where dm.uf_id = ${estado} and est.ano = ${ano} 
-  group by mes
-  order by mes
-`
-      );
-      result[i] = {
-        ano: ano,
-        area_queimada: anos.rows[i].area_queimada,
-        focos: anos.rows[i].focos,
-        percentual: anos.rows[i].percentual,
-        meses: query_meses.rows,
-      };
-    }
-
-    return result;
-  }
-}
-
-export async function estatisticasMunicipios(municipio: string, ano?: string) {
-  if (ano) {
-    const query_meses = await knex.raw(
-      `select 
-      est.mes,
-      est.total_area_queimada as area_queimada,
-      est.total_focos_queimada as focos,
-      ((est.total_area_queimada/1000000)/mm.area_km2) * 100 as percentual
-    from estatisticas_queimadas_municipios est
-    join mapas_municipios mm on mm.id = est.referencia_id
-    where est.referencia_id = ${municipio} and ano = ${ano}
-    order by mes  
-  `
-    );
-
-    return query_meses.rows;
-  } else {
-    const anos = await knex.raw(
-      `
+export async function estatisticasEstados(
+  estado: string,
+  ano?: string
+): Promise<Array<estatistica_ano>> {
+  const anos = await knex.raw(`
       select 
           est.ano,
           SUM(total_area_queimada) as area_queimada,
           SUM(total_focos_queimada) as focos,
-          ((SUM(total_area_queimada)/1000000)/
-          (select mm.area_km2 from mapas_municipios mm where mm.id = ${municipio})) * 100 as percentual
+          (SUM(total_area_queimada)/
+          (select ST_AREA(ST_MAKEVALID(me.wkb_geometry), true) from mapas_estados me where me.id = ${estado})) * 100 as percentual
       from estatisticas_queimadas_municipios est
-      where est.referencia_id = ${municipio}
+      join dados_municipios dm on dm.id = est.referencia_id 
+      where 
+        dm.uf_id = ${estado}
+        ${ano ? `and ano = ${ano}` : ''} 
       group by ano
-      order by ano  
-    `
-    );
-    const result: any = new Array<any>(anos.rows.length);
+      order by ano
+    `);
 
-    for (let index = 0; index < anos.rows.length; index++) {
-      const ano = anos.rows[index].ano;
-      const query_meses = await knex.raw(
-        `select 
-      est.mes,
-      est.total_area_queimada as area_queimada,
-      est.total_focos_queimada as focos,
-      ((est.total_area_queimada/1000000)/mm.area_km2) * 100 as percentual
-    from estatisticas_queimadas_municipios est
-    join mapas_municipios mm on mm.id = est.referencia_id
-    where est.referencia_id = ${municipio} and ano = ${ano}
-    order by mes  
-  `
-      );
-      result[index] = {
-        ano: ano,
-        area_queimada: anos.rows[index].area_queimada,
-        focos: anos.rows[index].focos,
-        percentual: anos.rows[index].percentual,
+  return await Promise.all(
+    anos.rows.map(async (row: estatistica_ano) => {
+      const query_meses = await knex.raw(`
+        select 
+          est.mes,
+          SUM(total_area_queimada) as area_queimada,
+          SUM(total_focos_queimada) as focos,
+          (SUM(total_area_queimada)/
+          (select ST_AREA(ST_MAKEVALID(me.wkb_geometry), true) from mapas_estados me where me.id = ${estado})) * 100 as percentual
+        from estatisticas_queimadas_municipios est
+        join dados_municipios dm on dm.id = est.referencia_id 
+        where 
+          dm.uf_id = ${estado} 
+          and est.ano = ${row.ano} 
+        group by mes
+        order by mes
+      `);
+      return {
+        ano: row.ano,
+        area_queimada: row.area_queimada,
+        focos: row.focos,
+        percentual: row.percentual,
         meses: query_meses.rows,
       };
-    }
+    })
+  );
+}
 
-    return result;
-  }
+export async function estatisticasMunicipios(
+  municipio: string,
+  ano?: string
+): Promise<Array<estatistica_ano>> {
+  const anos = await knex.raw(`
+      select 
+          est.ano,
+          SUM(total_area_queimada) as area_queimada,
+          SUM(total_focos_queimada) as focos,
+          ((SUM(total_area_queimada)/1e6)/
+          (select mm.area_km2 from mapas_municipios mm where mm.id = ${municipio})) * 100 as percentual
+      from estatisticas_queimadas_municipios est
+      where 
+        est.referencia_id = ${municipio}
+        ${ano ? `and ano = ${ano}` : ''} 
+      group by ano
+      order by ano  
+  `);
+
+  return await Promise.all(
+    anos.rows.map(async (row: estatistica_ano) => {
+      const query_meses = await knex.raw(`
+      select 
+        est.mes,
+        est.total_area_queimada as area_queimada,
+        est.total_focos_queimada as focos,
+        ((est.total_area_queimada/1e6)/mm.area_km2) * 100 as percentual
+      from estatisticas_queimadas_municipios est
+      join mapas_municipios mm on mm.id = est.referencia_id
+      where 
+        est.referencia_id = ${municipio} 
+        and ano = ${row.ano}
+      order by mes  
+  `);
+      return {
+        ano: row.ano,
+        area_queimada: row.area_queimada,
+        focos: row.focos,
+        percentual: row.percentual,
+        meses: query_meses.rows,
+      };
+    })
+  );
 }
 
 export default {

--- a/server/common/api.yml
+++ b/server/common/api.yml
@@ -157,23 +157,13 @@ paths:
         - Estatisticas
       parameters:
         - $ref: '#/components/parameters/municipio_id'
+        - $ref: '#/components/parameters/year'
       responses:
         200:
           description: Retorna estatisticas de queimadas do municipio
         204:
           description: Não existem dados para a consulta
-  /estatisticas/municipios/{id}/{year}:
-    get:
-      tags:
-        - Estatisticas
-      parameters:
-        - $ref: '#/components/parameters/municipio_id'
-        - $ref: '#/components/parameters/year'
-      responses:
-        200:
-          description: Retorna estatisticas de queimadas do municipio no ano
-        204:
-          description: Não existem dados para a consulta
+
   /estatisticas/estados:
     get:
       tags:
@@ -184,17 +174,6 @@ paths:
         204:
           description: Não existem dados para a consulta
   /estatisticas/estados/{id}:
-    get:
-      tags:
-        - Estatisticas
-      parameters:
-        - $ref: '#/components/parameters/estado_id'
-      responses:
-        200:
-          description: Retorna estatisticas de queimadas do estado
-        204:
-          description: Não existem dados para a consulta
-  /estatisticas/estados/{id}/{year}:
     get:
       tags:
         - Estatisticas
@@ -378,12 +357,11 @@ components:
         default: latest
       required: true
     year:
-      in: path
+      in: query
       name: year
       schema:
         type: string
-        default: 2021
-      required: true
+      required: false
     full:
       in: query
       name: full


### PR DESCRIPTION
- Realiza ajustes e melhora performance no processamento das estatísticas.
- Ajusta endpoint de estatísticas do estado.
- Muda parâmetro do ano das estatísticas para query param.
- Refatora service de estatísticas.
- Ajusta para manter o padrão do json quando é filtrado pelo ano nos endpoints de estatísticas.
