### PR TITLE
25 padronizar tabelas de estatsticas

### DIFF
--- a/server/api/controllers/estatisticas/controller.ts
+++ b/server/api/controllers/estatisticas/controller.ts
@@ -1,18 +1,11 @@
 import { Request, Response } from 'express';
-import {
-  estatisticasEstados,
-  estadosComDados,
-  estatisticasMunicipios,
-  municipiosComDados,
-  biomasComDados,
-  estatisticasBiomas,
-} from '../../services/estatisticas.service';
+import { estatisticas, entidadesComDados } from '../../services/estatisticas.service';
 
 async function getEstatisticasMunicipios(req: Request, res: Response) {
   const municipio: string = req.params.municipio.toString();
   const ano: string | undefined = req.query.year?.toString();
 
-  const result = await estatisticasMunicipios(municipio, ano);
+  const result = await estatisticas('municipios', municipio, ano);
   return res.status(result ? 200 : 204).send(result);
 }
 
@@ -20,7 +13,7 @@ async function getEstatisticasEstados(req: Request, res: Response) {
   const estado: string = req.params.estado.toString();
   const ano: string | undefined = req.query.year?.toString();
 
-  const result = await estatisticasEstados(estado, ano);
+  const result = await estatisticas('estados', estado, ano);
   return res.status(result ? 200 : 204).send(result);
 }
 
@@ -28,22 +21,22 @@ async function getEstatisticasBiomas(req: Request, res: Response) {
   const bioma: string = req.params.bioma.toString();
   const ano: string | undefined = req.query.year?.toString();
 
-  const result = await estatisticasBiomas(bioma, ano);
+  const result = await estatisticas('biomas', bioma, ano);
   return res.status(result ? 200 : 204).send(result);
 }
 
 async function findMunicipios(_: Request, res: Response) {
-  const result = await municipiosComDados();
+  const result = await entidadesComDados('municipios');
   return res.status(result ? 200 : 204).send(result);
 }
 
 async function findBiomas(_: Request, res: Response) {
-  const result = await biomasComDados();
+  const result = await entidadesComDados('biomas');
   return res.status(result ? 200 : 204).send(result);
 }
 
 async function findEstados(_: Request, res: Response) {
-  const result = await estadosComDados();
+  const result = await entidadesComDados('estados');
   return res.status(result ? 200 : 204).send(result);
 }
 

--- a/server/api/services/populate-municipios.service.ts
+++ b/server/api/services/populate-municipios.service.ts
@@ -123,7 +123,7 @@ async function populateMapasMunicipios(override?: boolean) {
     await Promise.all([
       trx.schema.withSchema('public').raw(`
         CREATE TABLE public.mapas_estados AS 
-        SELECT cd_uf::integer AS id, nm_uf AS nome, sigla, nm_regiao AS regiao, wkb_geometry::geometry(polygon)
+        SELECT cd_uf::integer AS id, nm_uf AS nome, sigla, nm_regiao AS regiao, cd_uf::integer AS ref_id, wkb_geometry::geometry(polygon)
         FROM shapefiles.br_uf_2021
       `),
       trx.schema.withSchema('public').raw(`


### PR DESCRIPTION
Closes #25 

- Adiciona colunas de área em m2 para os mapas de Estados e Biomas.
- Converte coluna de área de km2 para m2 na tabela de mapas de municípios.
- Cria tabela de estatísticas e dados de queimadas para Estados.
- Remove a trigger que alimente a tabela de estatísticas.
- Preenche a tabela de estatísticas no fim do processamento.
- Processa biomas e municípios ao mesmo tempo.
- Refatora serviço de estatísticas unificando consultas para todos os tipos de mapas.